### PR TITLE
chore: removing aws account id from bucket name

### DIFF
--- a/src/cdk/bin/config/environments.ts
+++ b/src/cdk/bin/config/environments.ts
@@ -36,7 +36,7 @@ export const environments: Record<string, EnvironmentConfig> = {
     allocatedStorage: 20,
   },
   prod: {
-    account: getRequiredEnvVar('PREPROD_AWS_ACCOUNT_ID', 'preprod'),
+    account: getRequiredEnvVar('PREPROD_AWS_ACCOUNT_ID', 'preprod'), // TODO: change to prod when AWS account is created
     region: 'sa-east-1',
     environment: 'prod',
     resourcePrefix: 'eah-preprod',

--- a/src/cdk/lib/constructs/NotesStateful.ts
+++ b/src/cdk/lib/constructs/NotesStateful.ts
@@ -62,7 +62,7 @@ export class NotesStateful extends Construct {
     
     // S3 bucket for images
     this.imagesBucket = new s3.Bucket(this, 'ImagesBucket', {
-      bucketName: `${environmentConfig.resourcePrefix}-images-${cdk.Aws.ACCOUNT_ID}`,
+      bucketName: `${environmentConfig.resourcePrefix}-images`,
       cors: [{
         allowedMethods: [s3.HttpMethods.GET, s3.HttpMethods.POST, s3.HttpMethods.PUT, s3.HttpMethods.DELETE],
         allowedOrigins: ['*'], // Configure based on environment in production


### PR DESCRIPTION
This PR removes AWS account id from bucket name.